### PR TITLE
Bump to 7.11.1

### DIFF
--- a/.github/workflows/ansible-test-deploy.yml
+++ b/.github/workflows/ansible-test-deploy.yml
@@ -43,7 +43,7 @@ jobs:
         shell: powershell
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install cryptography==3.3.2 ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -46,7 +46,7 @@ jobs:
         shell: powershell
       - name: Install Ansible
         shell: msys2 {0}
-        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install ansible pywinrm
+        run: CFLAGS=-I/usr/lib/libffi-3.2.1/include python -m pip install cryptography==3.3.2 ansible pywinrm
       - name: Run Ansible playbook
         shell: msys2 {0}
         run: |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,5 +26,5 @@ winlogbeat_output:
 winlogbeat_service:
   install_path_64: "C:\\Program Files\\Elastic\\winlogbeat"
   install_path_32: "C:\\Program Files (x86)\\Elastic\\winlogbeat"
-  version: "7.10.2"
+  version: "7.11.1"
   download: true


### PR DESCRIPTION
- Workaround for cryptography breaking Github Actions
- [7.11.1 changes](https://www.elastic.co/guide/en/beats/libbeat/7.11/release-notes-7.11.1.html)